### PR TITLE
Update so that "getBowerConfig()" doesn't grab dependencies that aren…

### DIFF
--- a/wiredep-away.js
+++ b/wiredep-away.js
@@ -103,7 +103,8 @@ function getBowerConfig(cwd) {
 
   Object.keys(packageObj.dependencies)
     .map(function (dep) {
-      return dependencies[dep.replace('@bower_components/', '')] = packageObj.dependencies[dep];
+      if(dep.indexOf('@bower_components/') !== -1)
+      		return dependencies[dep.replace('@bower_components/', '')] = packageObj.dependencies[dep];
     });
 
   return {


### PR DESCRIPTION
…'t prefixed "@bower_components/"